### PR TITLE
Added the zstd package under the prerequisites section in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,12 @@ Created by ![endercatcore icon](./assets/buttonicons/credit_end.png)[EnderCatCor
 ## Prerequisites
 - Wine *(while LHL automatically installs Wine 9, Wine is still required on your system for it to work properly)*
 - Winetricks
-- Libunwind8
 - Zstd
 
 You can install Wine & Winetricks on Debian-based distros by running these comamnds:
 ```
 sudo apt update
-sudo apt install wine winetricks libunwind8 zstd
+sudo apt install wine winetricks zstd
 ```
 
 Please note that immutable distros (such as SteamOS and Bazzite) will most likely **not** work with Linux Hammer Launcher. You can try, but don't be suprised if it won't launch or run correctly. 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Created by ![endercatcore icon](./assets/buttonicons/credit_end.png)[EnderCatCor
 ## Prerequisites
 - Wine *(while LHL automatically installs Wine 9, Wine is still required on your system for it to work properly)*
 - Winetricks
-- Libunwind
+- Libunwind8
 - Zstd
 
 You can install Wine & Winetricks on Debian-based distros by running these comamnds:

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ Created by ![endercatcore icon](./assets/buttonicons/credit_end.png)[EnderCatCor
 ## Prerequisites
 - Wine *(while LHL automatically installs Wine 9, Wine is still required on your system for it to work properly)*
 - Winetricks
+- Libunwind
+- Zstd
 
 You can install Wine & Winetricks on Debian-based distros by running these comamnds:
 ```
 sudo apt update
-sudo apt install wine winetricks
+sudo apt install wine winetricks libunwind8 zstd
 ```
 
 Please note that immutable distros (such as SteamOS and Bazzite) will most likely **not** work with Linux Hammer Launcher. You can try, but don't be suprised if it won't launch or run correctly. 


### PR DESCRIPTION
Added `zstd` package under the Prerequisites section

Without `zstd` program cannot extract the downloaded `wine-9.0-1-x86_64.pkg.tar.zst` archive